### PR TITLE
Campaign sequence

### DIFF
--- a/components/Campaign/CampaignCard.js
+++ b/components/Campaign/CampaignCard.js
@@ -26,7 +26,7 @@ const CampaignCard = () => {
         <Flex direction="column" justifyContent="space-between">
           <Text fontSize="xl">12/31/22 - 12/31/22</Text>
           <Center>
-            <Button variant="ghost" size="sm" color="#2D285C">
+            <Button variant="ghost" size="sm" colorScheme="brand">
               View Details
             </Button>
           </Center>

--- a/components/Campaign/CampaignModal.js
+++ b/components/Campaign/CampaignModal.js
@@ -1,0 +1,77 @@
+import { useEffect, useReducer, useState } from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Button,
+  Text,
+} from "@chakra-ui/react";
+import CampaignInfo from "./Carousel/CampaignInfo";
+import { Switch, Case } from "react-if";
+import CampaignTarget from "./Carousel/CampaignTarget";
+import CampaignAssignments from "./Carousel/CampaignAssignments";
+import axios from "axios";
+
+const modalTitles = {
+  0: "Create new campaign",
+  1: "Campaign focus",
+  2: "Assignments",
+};
+
+const CampaignModal = ({ isOpen, onClose }) => {
+  const [currentPage, setCurrentPage] = useState(0);
+  const [campaignForm, setCampaignForm] = useState({
+    campaignName: "",
+    campaignDescription: "",
+    campaignStartDate: null,
+  });
+  const [counties, setCounties] = useState([]);
+  const [legislators, setLegislators] = useState([]);
+
+  useEffect(async () => {
+    const res = await axios.get("/api/campaign");
+    setCounties(res.data.counties);
+    setLegislators(res.data.legislators);
+  }, []);
+
+  return (
+    <Modal size="xl" isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{modalTitles[currentPage]}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Switch>
+            <Case condition={currentPage === 0}>
+              <CampaignInfo
+                setCurrentPage={setCurrentPage}
+                campaignForm={campaignForm}
+                setCampaignForm={setCampaignForm}
+              />
+            </Case>
+            <Case condition={currentPage === 1}>
+              <CampaignTarget
+                setCurrentPage={setCurrentPage}
+                campaignForm={campaignForm}
+                setCampaignForm={setCampaignForm}
+                counties={counties}
+                setCounties={setCounties}
+                legislators={legislators}
+                setLegislators={setLegislators}
+              />
+            </Case>
+            <Case condition={currentPage === 2}>
+              <CampaignAssignments setCurrentPage={setCurrentPage} />
+            </Case>
+          </Switch>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default CampaignModal;

--- a/components/Campaign/Carousel/CampaignAssignments.js
+++ b/components/Campaign/Carousel/CampaignAssignments.js
@@ -1,0 +1,21 @@
+import { Text, Box, Divider, Flex, Button } from "@chakra-ui/react";
+
+const CampaignAssignments = ({ setCurrentPage }) => {
+  return (
+    <>
+      <Text>Assignments</Text>
+
+      <Box mb={3}>
+        <Divider color="gray.400" mb={4} />
+        <Flex justifyContent="space-between">
+          <Button colorScheme="gray" onClick={() => setCurrentPage(1)}>
+            Back
+          </Button>
+          <Button colorScheme="brand">Submit</Button>
+        </Flex>
+      </Box>
+    </>
+  );
+};
+
+export default CampaignAssignments;

--- a/components/Campaign/Carousel/CampaignInfo.js
+++ b/components/Campaign/Carousel/CampaignInfo.js
@@ -136,5 +136,6 @@ const CampaignInfo = ({ setCurrentPage, campaignForm, setCampaignForm }) => {
     </>
   );
 };
+CampaignInfo.displayName = "CampaignInfo";
 
 export default CampaignInfo;

--- a/components/Campaign/Carousel/CampaignInfo.js
+++ b/components/Campaign/Carousel/CampaignInfo.js
@@ -1,0 +1,140 @@
+import { forwardRef, useState } from "react";
+import {
+  Box,
+  Text,
+  Input,
+  Stack,
+  FormControl,
+  FormLabel,
+  FormErrorMessage,
+  Textarea,
+  Divider,
+  Button,
+  Flex,
+} from "@chakra-ui/react";
+import DatePicker from "react-datepicker";
+import { Form, Formik, Field, useFormikContext, useField } from "formik";
+
+const validateReq = (value) => {
+  let error;
+  if (!value) {
+    error = "Required field";
+  }
+  return error;
+};
+
+const CustomDateInput = forwardRef(
+  ({ value, onClick, setFieldTouched }, ref) => (
+    <Input
+      ref={ref}
+      defaultValue={value}
+      isReadOnly
+      onClick={() => {
+        onClick();
+        setFieldTouched("campaignStartDate", true, true);
+      }}
+    />
+  )
+);
+
+const DatePickerField = ({ ...props }) => {
+  const { setFieldValue } = useFormikContext();
+  const [field] = useField(props);
+
+  return (
+    <DatePicker
+      {...field}
+      {...props}
+      isClearable
+      selected={field.value}
+      onChange={(val) => {
+        setFieldValue(field.name, val);
+      }}
+      customInput={
+        <CustomDateInput
+          id="campaignStartDate"
+          setFieldTouched={props.setFieldTouched}
+        />
+      }
+    />
+  );
+};
+
+const CampaignInfo = ({ setCurrentPage, campaignForm, setCampaignForm }) => {
+  return (
+    <>
+      <Formik
+        initialValues={campaignForm}
+        onSubmit={(values) => {
+          setCampaignForm(values);
+          setCurrentPage(1);
+        }}
+      >
+        {(props) => (
+          <Form>
+            <Stack direction="column" spacing={4}>
+              <Field name="campaignName" validate={validateReq}>
+                {({ field, form }) => (
+                  <FormControl
+                    isRequired
+                    isInvalid={
+                      form.errors.campaignName && form.touched.campaignName
+                    }
+                  >
+                    <FormLabel htmlFor="campaignName">Campaign name</FormLabel>
+                    <Input {...field} id="campaignName" />
+                    <FormErrorMessage>
+                      {form.errors.campaignName}
+                    </FormErrorMessage>
+                  </FormControl>
+                )}
+              </Field>
+              <Field name="campaignDescription">
+                {({ field, form }) => (
+                  <FormControl>
+                    <FormLabel htmlFor="campaignDescription">
+                      Description/Purpose
+                    </FormLabel>
+                    <Textarea {...field} id="campaignDescription" />
+                    <FormErrorMessage>
+                      {form.errors.campaignDescription}
+                    </FormErrorMessage>
+                  </FormControl>
+                )}
+              </Field>
+              <Field name="campaignStartDate" validate={validateReq}>
+                {({ field, form }) => (
+                  <FormControl
+                    isRequired
+                    isInvalid={
+                      form.errors.campaignStartDate &&
+                      form.touched.campaignStartDate
+                    }
+                  >
+                    <FormLabel htmlFor="campaignStartDate">
+                      Start date
+                    </FormLabel>
+                    <DatePickerField {...form} name="campaignStartDate" />
+                    <FormErrorMessage>
+                      {form.errors.campaignStartDate}
+                    </FormErrorMessage>
+                  </FormControl>
+                )}
+              </Field>
+            </Stack>
+            <Box mt={6} mb={4}>
+              <Divider color="gray.400" mb={4} />
+              <Flex justifyContent="right">
+                <Button colorScheme="brand" type="submit">
+                  Next
+                </Button>
+              </Flex>
+            </Box>
+          </Form>
+        )}
+      </Formik>
+    </>
+  );
+};
+
+export default CampaignInfo;

--- a/components/Campaign/Carousel/CampaignInfo.js
+++ b/components/Campaign/Carousel/CampaignInfo.js
@@ -36,6 +36,7 @@ const CustomDateInput = forwardRef(
     />
   )
 );
+CustomDateInput.displayName = "CustomDateInput";
 
 const DatePickerField = ({ ...props }) => {
   const { setFieldValue } = useFormikContext();
@@ -136,6 +137,5 @@ const CampaignInfo = ({ setCurrentPage, campaignForm, setCampaignForm }) => {
     </>
   );
 };
-CampaignInfo.displayName = "CampaignInfo";
 
 export default CampaignInfo;

--- a/components/Campaign/Carousel/CampaignTarget.js
+++ b/components/Campaign/Carousel/CampaignTarget.js
@@ -1,0 +1,139 @@
+import {
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Tab,
+  Text,
+  Checkbox,
+  Stack,
+  Box,
+  Divider,
+  Flex,
+  Button,
+} from "@chakra-ui/react";
+import axios from "axios";
+import { useEffect, useMemo, useState } from "react";
+
+const CampaignTarget = ({
+  setCurrentPage,
+  campaignForm,
+  setCampaignForm,
+  counties,
+  setCounties,
+  legislators,
+  setLegislators,
+}) => {
+  return (
+    <>
+      <Tabs variant="soft-rounded" colorScheme="brand" align="center">
+        <TabList>
+          <Tab>Counties</Tab>
+          <Tab>Legislators</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Flex direction="row">
+              <Box flex={1}>
+                <Text fontSize="lg" fontWeight={600} mb={2}>
+                  Choose counties
+                </Text>
+                <Stack direction="column">
+                  {Object.keys(counties).map((county) => (
+                    <Checkbox
+                      key={`checkbox-${county}`}
+                      colorScheme="brand"
+                      isChecked={counties[county]}
+                      onChange={() => {
+                        const newCounties = { ...counties };
+                        newCounties[county] = !newCounties[county];
+                        setCounties(newCounties);
+                      }}
+                    >
+                      {county}
+                    </Checkbox>
+                  ))}
+                </Stack>
+              </Box>
+              <Box flex={1}>
+                <Text fontSize="lg" fontWeight={600} mb={2}>
+                  Selected counties
+                </Text>
+                <Stack direction="column">
+                  {Object.keys(counties)
+                    .filter((county) => counties[county])
+                    .map((county) => (
+                      <Text key={`selected-${county}`}>{county}</Text>
+                    ))}
+                </Stack>
+              </Box>
+            </Flex>
+          </TabPanel>
+          <TabPanel>
+            <Flex direction="row">
+              <Box flex={1}>
+                <Text fontSize="lg" fontWeight={600} mb={2}>
+                  Choose legislators
+                </Text>
+                <Stack direction="column">
+                  {Object.keys(legislators).map((legislatorId) => (
+                    <Checkbox
+                      key={`checkbox-${legislatorId}`}
+                      colorScheme="brand"
+                      isChecked={legislators[legislatorId].selected}
+                      onChange={() => {
+                        const newLegislators = { ...legislators };
+                        const newLegislator = {
+                          ...legislators[legislatorId],
+                          selected: !legislators[legislatorId].selected,
+                        };
+                        newLegislators[legislatorId] = newLegislator;
+                        setLegislators(newLegislators);
+                      }}
+                    >
+                      {legislators[legislatorId].firstName}{" "}
+                      {legislators[legislatorId].lastName}
+                    </Checkbox>
+                  ))}
+                </Stack>
+              </Box>
+              <Box flex={1}>
+                <Text fontSize="lg" fontWeight={600} mb={2}>
+                  Selected legislators
+                </Text>
+                <Stack direction="column">
+                  {Object.keys(legislators)
+                    .filter(
+                      (legislatorId) => legislators[legislatorId].selected
+                    )
+                    .map((legislatorId) => (
+                      <Text key={`selected-${legislatorId}`}>
+                        {legislators[legislatorId].firstName}{" "}
+                        {legislators[legislatorId].lastName}
+                      </Text>
+                    ))}
+                </Stack>
+              </Box>
+            </Flex>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+      <Box mb={3}>
+        <Divider color="gray.400" mb={4} />
+        <Flex justifyContent="space-between">
+          <Button colorScheme="gray" onClick={() => setCurrentPage(0)}>
+            Back
+          </Button>
+          <Button
+            colorScheme="brand"
+            onClick={() => /* validation */ setCurrentPage(2)}
+          >
+            Next
+          </Button>
+        </Flex>
+      </Box>
+    </>
+  );
+};
+
+export default CampaignTarget;

--- a/components/CampaignCard.js
+++ b/components/CampaignCard.js
@@ -1,0 +1,39 @@
+import { Box, Flex, Text, Button, Center } from "@chakra-ui/react";
+
+const CampaignCard = () => {
+  return (
+    <Box
+      padding={4}
+      w={800}
+      borderColor="black"
+      borderRadius={6}
+      borderStyle="solid"
+      borderWidth={0.8}
+    >
+      <Flex direction="row" justifyContent="space-between">
+        <Flex direction="column" flex="4">
+          <Text fontSize="xl">Campaign Title</Text>
+          <Text>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </Text>
+        </Flex>
+        <Flex direction="column" justifyContent="space-between">
+          <Text fontSize="xl">12/31/22 - 12/31/22</Text>
+          <Center>
+            <Button variant="ghost" size="sm" color="#2D285C">
+              View Details
+            </Button>
+          </Center>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+};
+
+export default CampaignCard;

--- a/components/LegislatorAddModal.js
+++ b/components/LegislatorAddModal.js
@@ -1,171 +1,188 @@
 import {
-    Box,
-    Modal,
-    ModalOverlay,
-    ModalContent,
-    ModalHeader,
-    ModalBody,
-    ModalCloseButton,
-    FormControl,
-    FormLabel,
-    FormErrorMessage,
-    Stack,
-    Button,
-    Input,
-    Flex,
-    IconButton,
-    Divider,
-  } from "@chakra-ui/react";
-  import { Field, FieldArray, Form, Formik } from "formik";
-  import { AddIcon, MinusIcon } from "@chakra-ui/icons";
-  import axios from "axios";
-  
-  const validateReq = (value) => {
-    let error;
-    if (!value) {
-      error = "Required field";
-    }
-    return error;
-  };
-  
-  const LegislatorAddModal = ({ isOpen, onClose, legislators, setLegislators }) => {
-    const handleAddSubmit = async (values, actions) => {
-      const prunedVals = { ...values };
-      prunedVals.counties = prunedVals.counties.filter((e) => e);
+  Box,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  FormControl,
+  FormLabel,
+  FormErrorMessage,
+  Stack,
+  Button,
+  Input,
+  Flex,
+  IconButton,
+  Divider,
+} from "@chakra-ui/react";
+import { Field, FieldArray, Form, Formik } from "formik";
+import { AddIcon, MinusIcon } from "@chakra-ui/icons";
+import axios from "axios";
 
-      const res = await axios.post("/api/legislator", {
-        type: "add",
-        formData: prunedVals,
+const validateReq = (value) => {
+  let error;
+  if (!value) {
+    error = "Required field";
+  }
+  return error;
+};
+
+const LegislatorAddModal = ({
+  isOpen,
+  onClose,
+  legislators,
+  setLegislators,
+}) => {
+  const handleAddSubmit = async (values, actions) => {
+    const prunedVals = { ...values };
+    prunedVals.counties = prunedVals.counties.filter((e) => e);
+
+    const res = await axios.post("/api/legislator", {
+      type: "add",
+      formData: prunedVals,
+    });
+    const newLegislator = res.data;
+
+    if (res.status === 200) {
+      newLegislator.counties = newLegislator.counties
+        .map((county) => county.name)
+        .join(", ");
+      setLegislators([...legislators, newLegislator]);
+      // onClose();
+      actions.resetForm();
+    } else {
+      actions.setErrors({
+        api: "There was an error when adding to the database.",
       });
-      const newLegislator = res.data;
-      
-      if (res.status === 200) {
-        newLegislator.counties = newLegislator.counties
-          .map((county) => county.name)
-          .join(", ");
-        setLegislators([...legislators, newLegislator]);
-        // onClose();
-        actions.resetForm();
-      } else {
-        actions.setErrors({api: 'There was an error when adding to the database.'});
-      }
-    };
-
-    return (
-      <Modal isOpen={isOpen} onClose={onClose}>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Add a Legislator</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            <Formik
-              initialValues={{
-                firstName: "",
-                lastName: "",
-                party: "",
-                counties: [""],
-              }}
-              onSubmit={handleAddSubmit}
-            >
-              {(props) => (
-                <Form>
-                  <Stack direction="column" spacing={4}>
-                    <Field name="firstName" validate={validateReq}>
-                      {({ field, form }) => (
-                        <FormControl
-                          isInvalid={form.errors.firstName && form.touched.firstName}
-                          isRequired
-                        >
-                          <FormLabel htmlFor="firstName">First Name</FormLabel>
-                          <Input {...field} id="firstName" placeholder="George" />
-                          <FormErrorMessage>{form.errors.firstName}</FormErrorMessage>
-                        </FormControl>
-                      )}
-                    </Field>
-
-                    <Field name="lastName" validate={validateReq}>
-                      {({ field, form }) => (
-                        <FormControl
-                          isInvalid={form.errors.lastName && form.touched.lastName}
-                          isRequired
-                        >
-                          <FormLabel htmlFor="lastName">Last Name</FormLabel>
-                          <Input {...field} id="lastName" placeholder="Burdell" />
-                          <FormErrorMessage>{form.errors.lastName}</FormErrorMessage>
-                        </FormControl>
-                      )}
-                    </Field>
-
-                    <Field name="party">
-                      {({ field, form }) => (
-                        <FormControl>
-                          <FormLabel htmlFor="party">Party</FormLabel>
-                          <Input {...field} id="party" placeholder="Independent" />
-                          <FormErrorMessage>{form.errors.party}</FormErrorMessage>
-                        </FormControl>
-                      )}
-                    </Field>
-                
-                    <Box>
-                      <FieldArray name="counties">
-                        {(arrayHelpers) => (
-                          <>
-                            <Flex direction="row">
-                              <FormLabel htmlFor="counties">Counties</FormLabel>
-                              <Stack direction="row" spacing={1}>
-                                <IconButton
-                                  size="xs"
-                                  icon={<MinusIcon />}
-                                  onClick={() =>
-                                    arrayHelpers.pop()
-                                  }
-                                />
-                                <IconButton
-                                  size="xs"
-                                  icon={<AddIcon />}
-                                  onClick={() => arrayHelpers.push("")}
-                                />
-                              </Stack>
-                            </Flex>
-  
-                            <Stack direction="column" spacing={2}>
-                              {props.values.counties.map((county, ind) => (
-                                <Field key={ind} name={`counties.${ind}`}>
-                                  {({ field, form }) => (
-                                    <Input {...field} id={`county-${ind}`} />
-                                  )}
-                                </Field>
-                              ))}
-                            </Stack>
-                          </>
-                        )}
-                      </FieldArray>
-                      {props.errors.api && props.errors.api}
-                    </Box>
-                  </Stack>
-                  <Box mt={6} mb={4}>
-                    <Divider color="gray.400" mb={4} />
-                    <Flex justifyContent="right">
-                      <Button
-                        colorScheme="red"
-                        variant="ghost"
-                        mr={3}
-                        onClick={onClose}
-                      >
-                        Cancel
-                      </Button>
-                      <Button colorScheme="teal" type="submit">
-                        Submit
-                      </Button>
-                    </Flex>
-                  </Box>
-                </Form>
-              )}
-            </Formik>
-          </ModalBody>
-        </ModalContent>
-      </Modal>
-    );
+    }
   };
-  
-  export default LegislatorAddModal;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Add a Legislator</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Formik
+            initialValues={{
+              firstName: "",
+              lastName: "",
+              party: "",
+              counties: [""],
+            }}
+            onSubmit={handleAddSubmit}
+          >
+            {(props) => (
+              <Form>
+                <Stack direction="column" spacing={4}>
+                  <Field name="firstName" validate={validateReq}>
+                    {({ field, form }) => (
+                      <FormControl
+                        isInvalid={
+                          form.errors.firstName && form.touched.firstName
+                        }
+                        isRequired
+                      >
+                        <FormLabel htmlFor="firstName">First Name</FormLabel>
+                        <Input {...field} id="firstName" placeholder="George" />
+                        <FormErrorMessage>
+                          {form.errors.firstName}
+                        </FormErrorMessage>
+                      </FormControl>
+                    )}
+                  </Field>
+
+                  <Field name="lastName" validate={validateReq}>
+                    {({ field, form }) => (
+                      <FormControl
+                        isInvalid={
+                          form.errors.lastName && form.touched.lastName
+                        }
+                        isRequired
+                      >
+                        <FormLabel htmlFor="lastName">Last Name</FormLabel>
+                        <Input {...field} id="lastName" placeholder="Burdell" />
+                        <FormErrorMessage>
+                          {form.errors.lastName}
+                        </FormErrorMessage>
+                      </FormControl>
+                    )}
+                  </Field>
+
+                  <Field name="party">
+                    {({ field, form }) => (
+                      <FormControl>
+                        <FormLabel htmlFor="party">Party</FormLabel>
+                        <Input
+                          {...field}
+                          id="party"
+                          placeholder="Independent"
+                        />
+                        <FormErrorMessage>{form.errors.party}</FormErrorMessage>
+                      </FormControl>
+                    )}
+                  </Field>
+
+                  <Box>
+                    <FieldArray name="counties">
+                      {(arrayHelpers) => (
+                        <>
+                          <Flex direction="row">
+                            <FormLabel htmlFor="counties">Counties</FormLabel>
+                            <Stack direction="row" spacing={1}>
+                              <IconButton
+                                size="xs"
+                                icon={<MinusIcon />}
+                                onClick={() => arrayHelpers.pop()}
+                              />
+                              <IconButton
+                                size="xs"
+                                icon={<AddIcon />}
+                                onClick={() => arrayHelpers.push("")}
+                              />
+                            </Stack>
+                          </Flex>
+
+                          <Stack direction="column" spacing={2}>
+                            {props.values.counties.map((county, ind) => (
+                              <Field key={ind} name={`counties.${ind}`}>
+                                {({ field, form }) => (
+                                  <Input {...field} id={`county-${ind}`} />
+                                )}
+                              </Field>
+                            ))}
+                          </Stack>
+                        </>
+                      )}
+                    </FieldArray>
+                    {props.errors.api && props.errors.api}
+                  </Box>
+                </Stack>
+                <Box mt={6} mb={4}>
+                  <Divider color="gray.400" mb={4} />
+                  <Flex justifyContent="right">
+                    <Button
+                      colorScheme="red"
+                      variant="ghost"
+                      mr={3}
+                      onClick={onClose}
+                    >
+                      Cancel
+                    </Button>
+                    <Button colorScheme="teal" type="submit">
+                      Submit
+                    </Button>
+                  </Flex>
+                </Box>
+              </Form>
+            )}
+          </Formik>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default LegislatorAddModal;

--- a/components/NavBar.jsx
+++ b/components/NavBar.jsx
@@ -1,110 +1,106 @@
 import React from "react";
 import { signIn, signOut } from "next-auth/react";
-import { 
-    Box,
-    Button,
-    Divider,
-    Image,
-    Stack 
-} from "@chakra-ui/react";
-import { 
-    MdOutlineCampaign,
-    MdOutlinePeople,
-    MdOutlinePerson
+import { Box, Button, Divider, Image, Stack } from "@chakra-ui/react";
+import {
+  MdOutlineCampaign,
+  MdOutlinePeople,
+  MdOutlinePerson,
 } from "react-icons/md";
 import { FiHome, FiLogIn, FiLogOut } from "react-icons/fi";
 import { BsNewspaper } from "react-icons/bs";
 import { VscLaw } from "react-icons/vsc";
-import Link from 'next/link'
-
+import Link from "next/link";
 
 const NavBar = ({ session }) => {
-    return (
-        <Stack padding={2} width={180} direction="column" >
-            <Image 
-                src="/FairDistrictsGA-Logo.png"
-                objectFit="cover"
-                maxWidth={80}
-                maxHeight={86}
-                paddingBottom={15}
-            />
-            <Divider />
-            <Stack direction="column" spacing={3} paddingTop={2}>
-            <   Link href="/">
-                    <Button 
-                        leftIcon={<FiHome />}
-                        variant="ghost"
-                        justifyContent="flex-start"
-                    >
-                            Home
-                    </Button>
-                </Link>
-                <Link href="/campaign">
-                    <Button 
-                        leftIcon={<MdOutlineCampaign />} 
-                        variant="ghost" 
-                        justifyContent="flex-start"
-                    >
-                            Campaign
-                    </Button>
-                </Link>
-                <Link href="/volunteer">
-                    <Button 
-                        leftIcon={<MdOutlinePeople />}
-                        variant="ghost"
-                        justifyContent="flex-start"
-                    >
-                            Volunteer
-                    </Button>
-                </Link>
-                <Link href="/newspaper">
-                    <Button
-                        leftIcon={<BsNewspaper />}
-                        variant="ghost"
-                        justifyContent="flex-start"
-                    >
-                            Newspapers
-                    </Button>
-                </Link>
-                <Link href="/legislator">
-                      <Button
-                        leftIcon={<VscLaw />}
-                        variant="ghost"
-                        justifyContent="flex-start"
-                    >
-                            Legislators
-                    </Button>
-                </Link>
-            </Stack>
-            <Box color="white" paddingTop={250} />
-            <Divider />
-            <Stack orientation="vertical" spacing={3}>
-                <Button 
-                    leftIcon={<MdOutlinePerson />}
-                    variant="ghost"
-                    justifyContent="flex-start"
-                >
-                    Profile
-                </Button>
-                { session
-                    ? <Button
-                        leftIcon={<FiLogOut />}
-                        variant="ghost"
-                        onClick={signOut}
-                        justifyContent="flex-start">
-                            Log Out
-                        </Button>
-                    : <Button
-                        leftIcon={<FiLogIn />}
-                        variant="ghost" 
-                        onClick={signIn}
-                        justifyContent="flex-start">
-                            Log In
-                        </Button>
-                }
-            </Stack>
-        </Stack>
-    );
+  return (
+    <Stack padding={2} width={180} direction="column">
+      <Image
+        src="/FairDistrictsGA-Logo.png"
+        objectFit="cover"
+        maxWidth={80}
+        maxHeight={86}
+        paddingBottom={15}
+      />
+      <Divider />
+      <Stack direction="column" spacing={3} paddingTop={2}>
+        <Link href="/">
+          <Button
+            leftIcon={<FiHome />}
+            variant="ghost"
+            justifyContent="flex-start"
+          >
+            Home
+          </Button>
+        </Link>
+        <Link href="/campaign">
+          <Button
+            leftIcon={<MdOutlineCampaign />}
+            variant="ghost"
+            justifyContent="flex-start"
+          >
+            Campaign
+          </Button>
+        </Link>
+        <Link href="/volunteer">
+          <Button
+            leftIcon={<MdOutlinePeople />}
+            variant="ghost"
+            justifyContent="flex-start"
+          >
+            Volunteer
+          </Button>
+        </Link>
+        <Link href="/newspaper">
+          <Button
+            leftIcon={<BsNewspaper />}
+            variant="ghost"
+            justifyContent="flex-start"
+          >
+            Newspapers
+          </Button>
+        </Link>
+        <Link href="/legislator">
+          <Button
+            leftIcon={<VscLaw />}
+            variant="ghost"
+            justifyContent="flex-start"
+          >
+            Legislators
+          </Button>
+        </Link>
+      </Stack>
+      <Box color="white" paddingTop={250} />
+      <Divider />
+      <Stack orientation="vertical" spacing={3}>
+        <Button
+          leftIcon={<MdOutlinePerson />}
+          variant="ghost"
+          justifyContent="flex-start"
+        >
+          Profile
+        </Button>
+        {session ? (
+          <Button
+            leftIcon={<FiLogOut />}
+            variant="ghost"
+            onClick={signOut}
+            justifyContent="flex-start"
+          >
+            Log Out
+          </Button>
+        ) : (
+          <Button
+            leftIcon={<FiLogIn />}
+            variant="ghost"
+            onClick={signIn}
+            justifyContent="flex-start"
+          >
+            Log In
+          </Button>
+        )}
+      </Stack>
+    </Stack>
+  );
 };
 
 export default NavBar;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,10 @@
         "node-fetch": "^3.2.0",
         "nodemailer": "^6.7.2",
         "react": "^17.0.2",
+        "react-datepicker": "^4.6.0",
         "react-dom": "17.0.2",
         "react-icons": "^4.3.1",
+        "react-if": "^4.1.1",
         "react-table": "^7.7.0"
       },
       "devDependencies": {
@@ -4145,6 +4147,11 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "node_modules/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
@@ -4405,6 +4412,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debounce": {
@@ -8682,6 +8701,23 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.6.0.tgz",
+      "integrity": "sha512-JGSQnQSQYUkS7zvSaZuyHv5lxp3wMrN7GXV0VA0E9Ax9fL3Bb6E1pSXjL6C3WoeuV8dt/mItQfRkPpRGCrl/OA==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.2",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.24.0",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.12.0",
+        "react-popper": "^2.2.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17",
+        "react-dom": "^16.9.0 || ^17"
+      }
+    },
     "node_modules/react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -8724,6 +8760,17 @@
         "react": "*"
       }
     },
+    "node_modules/react-if": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-if/-/react-if-4.1.1.tgz",
+      "integrity": "sha512-frzHswesRqVVJ2XcGRoLyTvlB2yneib4R/FCqTG8AqBQnFdLNhqNODfzEA84EQZ0XwBAVe82Oe567kxaVmwj5w==",
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^16.x || ^17.x"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -8736,6 +8783,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/react-onclickoutside": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.1.tgz",
+      "integrity": "sha512-a5Q7CkWznBRUWPmocCvE8b6lEYw1s6+opp/60dCunhO+G6E4tDTO2Sd2jKE+leEnnrLAE2Wj5DlDHNqj5wPv1Q==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/react-onclickoutside/blob/master/FUNDING.md"
+      },
+      "peerDependencies": {
+        "react": "^15.5.x || ^16.x || ^17.x",
+        "react-dom": "^15.5.x || ^16.x || ^17.x"
+      }
+    },
+    "node_modules/react-popper": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17"
       }
     },
     "node_modules/react-refresh": {
@@ -13581,6 +13654,11 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
     "cli-boxes": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
@@ -13801,6 +13879,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "debounce": {
       "version": "1.2.1",
@@ -16981,6 +17064,19 @@
         "@babel/runtime": "^7.12.13"
       }
     },
+    "react-datepicker": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.6.0.tgz",
+      "integrity": "sha512-JGSQnQSQYUkS7zvSaZuyHv5lxp3wMrN7GXV0VA0E9Ax9fL3Bb6E1pSXjL6C3WoeuV8dt/mItQfRkPpRGCrl/OA==",
+      "requires": {
+        "@popperjs/core": "^2.9.2",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.24.0",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.12.0",
+        "react-popper": "^2.2.5"
+      }
+    },
     "react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -17015,6 +17111,12 @@
       "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
       "requires": {}
     },
+    "react-if": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-if/-/react-if-4.1.1.tgz",
+      "integrity": "sha512-frzHswesRqVVJ2XcGRoLyTvlB2yneib4R/FCqTG8AqBQnFdLNhqNODfzEA84EQZ0XwBAVe82Oe567kxaVmwj5w==",
+      "requires": {}
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -17024,6 +17126,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
       "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
+    },
+    "react-onclickoutside": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.1.tgz",
+      "integrity": "sha512-a5Q7CkWznBRUWPmocCvE8b6lEYw1s6+opp/60dCunhO+G6E4tDTO2Sd2jKE+leEnnrLAE2Wj5DlDHNqj5wPv1Q==",
+      "requires": {}
+    },
+    "react-popper": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "requires": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      }
     },
     "react-refresh": {
       "version": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "node-fetch": "^3.2.0",
     "nodemailer": "^6.7.2",
     "react": "^17.0.2",
+    "react-datepicker": "^4.6.0",
     "react-dom": "17.0.2",
     "react-icons": "^4.3.1",
+    "react-if": "^4.1.1",
     "react-table": "^7.7.0"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,25 @@
-import '../styles/globals.css'
+import "../styles/globals.css";
+import "react-datepicker/dist/react-datepicker.css";
 import "bootstrap/dist/css/bootstrap.min.css";
 import { SessionProvider } from "next-auth/react";
-import { ChakraProvider } from "@chakra-ui/react";
+import { ChakraProvider, extendTheme } from "@chakra-ui/react";
+
+const theme = extendTheme({
+  colors: {
+    brand: {
+      50: "#eeecff",
+      100: "#cdcaea",
+      200: "#aba6d8",
+      300: "#8983c8",
+      400: "#685fb7",
+      500: "#4f469e",
+      600: "#3d367b",
+      700: "#2b2759",
+      800: "#1a1737",
+      900: "#090718",
+    },
+  },
+});
 
 export default function App({
   Component,
@@ -9,9 +27,9 @@ export default function App({
 }) {
   return (
     <SessionProvider session={session}>
-      <ChakraProvider>
-        <Component {...pageProps} /> 
+      <ChakraProvider theme={theme}>
+        <Component {...pageProps} />
       </ChakraProvider>
     </SessionProvider>
   );
-}  
+}

--- a/pages/api/campaign.js
+++ b/pages/api/campaign.js
@@ -1,0 +1,35 @@
+import prisma from "../../prisma/prisma";
+
+async function handler(req, res) {
+  if (req.method === "GET") {
+    //tentative
+    await getCountiesLegislators(req, res);
+  }
+}
+
+async function getCountiesLegislators(req, res) {
+  const counties = await prisma.county.findMany();
+  const legislators = await prisma.legislator.findMany();
+  res.status(200).json({
+    counties: counties.reduce(
+      (prev, cur) => ({
+        ...prev,
+        [cur["name"]]: false,
+      }),
+      {}
+    ),
+    legislators: legislators.reduce(
+      (prev, cur) => ({
+        ...prev,
+        [cur["id"]]: {
+          firstName: cur.firstName,
+          lastName: cur.lastName,
+          selected: false,
+        },
+      }),
+      {}
+    ),
+  });
+}
+
+export default handler;

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -1,34 +1,68 @@
 import React from "react";
-import { Box, Button, Center, Flex, Heading, Stack } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Center,
+  Flex,
+  Heading,
+  Stack,
+  useDisclosure,
+} from "@chakra-ui/react";
 import NavBar from "../components/NavBar";
 import { AddIcon } from "@chakra-ui/icons";
-import CampaignCard from "../components/CampaignCard";
+import CampaignCard from "../components/Campaign/CampaignCard";
+import CampaignModal from "../components/Campaign/CampaignModal";
+import { getSession, useSession } from "next-auth/react";
 
 const Campaign = () => {
+  const { data: session } = useSession();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  if (!session) {
+    return <p>Access Denied</p>;
+  }
   return (
-    <Flex direction="row">
-      <NavBar />
-      <Box p={8} flex={1} h={800}>
-        <Heading>Campaigns</Heading>
-        <Center flexDir="column">
-          <Button
-            mb={10}
-            rightIcon={<AddIcon />}
-            bgColor="#2D285C"
-            textColor="white"
-            _hover={{ bgColor: "#57537d" }}
-          >
-            Create New Campaign
-          </Button>
-          <Stack direction="column" spacing={4} h={800} overflowY="scroll">
-            {Array.from(Array(10)).map(() => (
-              <CampaignCard />
-            ))}
-          </Stack>
-        </Center>
-      </Box>
-    </Flex>
+    <>
+      <Flex direction="row">
+        <NavBar />
+        <Box p={8} flex={1}>
+          <Heading>Campaigns</Heading>
+          <Center flexDir="column">
+            <Button
+              mb={10}
+              rightIcon={<AddIcon />}
+              colorScheme="brand"
+              onClick={onOpen}
+            >
+              Create New Campaign
+            </Button>
+            <Stack
+              direction="column"
+              spacing={4}
+              // h={650}
+              overflowY="scroll"
+              // display="flex"
+              // flexDir="column"
+              // flex={1}
+            >
+              {Array.from(Array(3)).map((i, j) => (
+                <CampaignCard key={j} />
+              ))}
+            </Stack>
+          </Center>
+        </Box>
+      </Flex>
+      <CampaignModal isOpen={isOpen} onClose={onClose} />
+    </>
   );
 };
+
+export async function getServerSideProps(context) {
+  // campaign fetch to go here
+  return {
+    props: {
+      session: await getSession(context),
+    },
+  };
+}
 
 export default Campaign;

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { Box, Button, Center, Flex, Heading, Stack } from "@chakra-ui/react";
+import NavBar from "../components/NavBar";
+import { AddIcon } from "@chakra-ui/icons";
+import CampaignCard from "../components/CampaignCard";
+
+const Campaign = () => {
+  return (
+    <Flex direction="row">
+      <NavBar />
+      <Box p={8} flex={1} h={800}>
+        <Heading>Campaigns</Heading>
+        <Center flexDir="column">
+          <Button
+            mb={10}
+            rightIcon={<AddIcon />}
+            bgColor="#2D285C"
+            textColor="white"
+            _hover={{ bgColor: "#57537d" }}
+          >
+            Create New Campaign
+          </Button>
+          <Stack direction="column" spacing={4} h={800} overflowY="scroll">
+            {Array.from(Array(10)).map(() => (
+              <CampaignCard />
+            ))}
+          </Stack>
+        </Center>
+      </Box>
+    </Flex>
+  );
+};
+
+export default Campaign;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,3 +14,108 @@ a {
 * {
   box-sizing: border-box;
 }
+
+.react-datepicker {
+  font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", sans-serif;
+  overflow: hidden;
+}
+
+.react-datepicker__navigation--next--with-time:not(.react-datepicker__navigation--next--with-today-button) {
+  right: 90px;
+}
+
+.react-datepicker__navigation--previous,
+.react-datepicker__navigation--next {
+  height: 8px;
+}
+
+.react-datepicker__navigation--previous {
+  border-right-color: #cbd5e0;
+}
+.react-datepicker__navigation--previous:hover {
+  border-right-color: #a0aec0;
+}
+
+.react-datepicker__navigation--next {
+  border-left-color: #cbd5e0;
+}
+.react-datepicker__navigation--next:hover {
+  border-left-color: #a0aec0;
+}
+
+.react-datepicker-wrapper,
+.react-datepicker__input-container {
+  display: block;
+}
+
+.react-datepicker__header {
+  border-radius: 0;
+  background: #f7fafc;
+}
+
+.react-datepicker,
+.react-datepicker__header,
+.react-datepicker__time-container {
+  border-color: #e2e8f0;
+}
+
+.react-datepicker__current-month,
+.react-datepicker-time__header,
+.react-datepicker-year-header {
+  font-size: inherit;
+  font-weight: 600;
+}
+
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item {
+  margin: 0 1px 0 0;
+  height: auto;
+  padding: 7px 10px;
+}
+
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item
+  :hover {
+  background: #edf2f7;
+}
+
+.react-datepicker__day:hover {
+  background: #edf2f7;
+}
+
+.react-datepicker__day--selected,
+.react-datepicker__day--in-selecting-range,
+.react-datepicker__day--in-range,
+.react-datepicker__month-text--selected,
+.react-datepicker__month-text--in-selecting-range,
+.react-datepicker__month-text--in-range,
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item--selected {
+  background: #3182ce;
+  font-weight: normal;
+}
+
+.react-datepicker__day--selected,
+.react-datepicker__day--in-selecting-range,
+.react-datepicker__day--in-range,
+.react-datepicker__month-text--selected,
+.react-datepicker__month-text--in-selecting-range,
+.react-datepicker__month-text--in-range,
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item--selected
+  :hover {
+  background: #2a69ac;
+}


### PR DESCRIPTION
## Campaign creation sequence

- New API route (`/api/campaign`) created to handle requests related to campaigns. For now I have a default `GET` method that fetches all counties and legislators each time a user initiates a campaign creation sequence.
- Design is very much a first-pass. Wanting to keep ChakraUI design consistent, decided to not use a multi-select for selection of counties and legislators since Chakra doesn't offer a multi-select, but am more than willing to refactor if we switch to BoG component library.
- The final "page" of the create campaign modal is a generic "Assignments" page with no content, assuming that the details for that page will be defined later.
- First page for campaign form has required field validation and input checking for date picker.
- Also, generic cells for campaign details were made, but CSS for overflowY to allow scrolling was tricky, so improvements could be made there.

Potential things to consider:
- Predefining counties since Georgia counties will stay constant
    - Would eliminate the need to create counties (typos would generate completely new counties currently, as an example)