### PR TITLE
Add newspaper groups

### DIFF
--- a/components/NewspaperAddModal.js
+++ b/components/NewspaperAddModal.js
@@ -64,10 +64,12 @@ const NewspaperAddModal = ({ isOpen, onClose, newspapers, setNewspapers }) => {
               instagram: "",
               twitter: "",
               counties: [""],
+              newspaperGroups: [""],
             }}
             onSubmit={async (values, actions) => {
               const prunedVals = { ...values };
               prunedVals.counties = prunedVals.counties.filter((e) => e);
+              prunedVals.newspaperGroups = prunedVals.newspaperGroups.filter((e) => e);
               prunedVals.rating = parseInt(prunedVals.rating);
               const res = await axios.post("/api/newspaper", {
                 type: "add",
@@ -200,6 +202,42 @@ const NewspaperAddModal = ({ isOpen, onClose, newspapers, setNewspapers }) => {
                                 {({ field, form }) => (
                                   <Flex direction="row" alignItems="center">
                                     <Input {...field} id={`county-${i}`} />
+                                    <IconButton
+                                      m={1}
+                                      size="xs"
+                                      icon={<MinusIcon />}
+                                      onClick={() => arrayHelpers.remove(i)}
+                                    />
+                                  </Flex>
+                                )}
+                              </Field>
+                            ))}
+                          </Stack>
+                        </>
+                      )}
+                    </FieldArray>
+                  </Box>
+                  <Box>
+                  <FieldArray name="newspaperGroups">
+                      {(arrayHelpers) => (
+                        <>
+                          <Flex direction="row">
+                            <FormLabel htmlFor="newspaperGroups">Groups</FormLabel>
+                            <Stack direction="row" spacing={1}>
+                              <IconButton
+                                size="xs"
+                                icon={<AddIcon />}
+                                onClick={() => arrayHelpers.push("")}
+                              />
+                            </Stack>
+                          </Flex>
+
+                          <Stack direction="column" spacing={2}>
+                            {props.values.newspaperGroups.map((group, i) => (
+                              <Field key={i} name={`newspaperGroups.${i}`}>
+                                {({ field, form }) => (
+                                  <Flex direction="row" alignItems="center">
+                                    <Input {...field} id={`newspaperGroup-${i}`} />
                                     <IconButton
                                       m={1}
                                       size="xs"

--- a/components/NewspaperEditModal.js
+++ b/components/NewspaperEditModal.js
@@ -28,6 +28,7 @@ import { AddIcon, MinusIcon } from "@chakra-ui/icons";
 import axios from "axios";
 import NewspaperAlertDialog from "./NewspaperAlertDialog";
 
+
 const validateName = (value) => {
   let error;
   if (!value) {
@@ -61,6 +62,7 @@ const NewspaperEditModal = ({
     return {
       ...newspaperMeta.newspaper,
       counties: newspaperMeta.newspaper.counties.map((c) => c.name),
+      newspaperGroups: newspaperMeta.newspaper.newspaperGroups.map((g) => g.name),
     };
   }, [newspaperMeta]);
 
@@ -90,6 +92,7 @@ const NewspaperEditModal = ({
                   onSubmit={async (values, actions) => {
                     const prunedVals = { ...values };
                     prunedVals.counties = prunedVals.counties.filter((e) => e);
+                    prunedVals.newspaperGroups = prunedVals.newspaperGroups.filter((e) => e);
                     prunedVals.rating = parseInt(prunedVals.rating);
                     const res = await axios.post("/api/newspaper", {
                       type: "edit",
@@ -244,6 +247,49 @@ const NewspaperEditModal = ({
                                           <Input
                                             {...field}
                                             id={`county-${i}`}
+                                          />
+                                          <IconButton
+                                            m={1}
+                                            size="xs"
+                                            icon={<MinusIcon />}
+                                            onClick={() =>
+                                              arrayHelpers.remove(i)
+                                            }
+                                          />
+                                        </Flex>
+                                      )}
+                                    </Field>
+                                  ))}
+                                </Stack>
+                              </>
+                            )}
+                          </FieldArray>
+                        </Box>
+                        <Box>
+                        <FieldArray name="newspaperGroups">
+                            {(arrayHelpers) => (
+                              <>
+                                <Flex direction="row">
+                                  <FormLabel htmlFor="newspaperGroups">
+                                    Groups
+                                  </FormLabel>
+                                  <IconButton
+                                    size="xs"
+                                    icon={<AddIcon />}
+                                    onClick={() => arrayHelpers.push("")}
+                                  />
+                                </Flex>
+                                <Stack direction="column" spacing={2}>
+                                  {props.values.newspaperGroups.map((group, i) => (
+                                    <Field key={i} name={`newspaperGroups.${i}`}>
+                                      {({ field, form }) => (
+                                        <Flex
+                                          direction="row"
+                                          alignItems="center"
+                                        >
+                                          <Input
+                                            {...field}
+                                            id={`newspaperGroup-${i}`}
                                           />
                                           <IconButton
                                             m={1}

--- a/pages/newspaper.js
+++ b/pages/newspaper.js
@@ -1,6 +1,5 @@
 import React, { useMemo, useState, useEffect } from "react";
 import Router from "next/router";
-
 import {
   Box,
   Table,
@@ -12,19 +11,18 @@ import {
   Heading,
   Flex,
   IconButton,
-  useDisclosure,
-  Center
+  useDisclosure
 } from "@chakra-ui/react";
 import { AddIcon, EditIcon } from "@chakra-ui/icons";
-import NewspaperAddModal from "../components/NewspaperAddModal";
 import axios from "axios";
 import { useTable, useRowSelect } from "react-table";
-import NewspaperEditModal from "../components/NewspaperEditModal";
 import { getSession, useSession } from "next-auth/react";
-import NavBar from "../components/NavBar";
+
 import AccessDeniedPage from "../components/AccessDeniedPage";
 import Loader from '../components/Loader';
-
+import NavBar from "../components/NavBar";
+import NewspaperAddModal from "../components/NewspaperAddModal";
+import NewspaperEditModal from "../components/NewspaperEditModal";
 
 
 const Newspaper = ({ data }) => {
@@ -106,6 +104,15 @@ const Newspaper = ({ data }) => {
             values: { counties },
           },
         }) => <div>{counties.map((c) => c.name).join(", ")}</div>,
+      },
+      {
+        Header: "Groups",
+        accessor: "newspaperGroups",
+        Cell: ({
+          row: {
+            values: { newspaperGroups },
+          },
+        }) => <div>{newspaperGroups.map((g) => g.name).join(", ")}</div>
       },
     ],
     []

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,16 +86,23 @@ model Assignment {
 }
 
 model Newspaper {
-  id          String       @id @default(cuid())
-  name        String       @unique
-  email       String?
-  rating      Int?
-  description String?
-  website     String?
-  instagram   String?
-  twitter     String?
-  assignments Assignment[]
-  counties    County[]
+  id             String           @id @default(cuid())
+  name           String           @unique
+  email          String?
+  rating         Int?
+  description    String?
+  website        String?
+  instagram      String?
+  twitter        String?
+  assignments    Assignment[]
+  counties       County[]
+  newspaperGroups NewspaperGroup[]
+}
+
+model NewspaperGroup {
+  id         String      @id @default(cuid())
+  name       String      @unique
+  newspapers Newspaper[]
 }
 
 model County {


### PR DESCRIPTION
## Adds Newspaper Groups

Issue Number(s): #36

What does this PR change and why?

Adds `NewspaperGroups` model to Prisma schema. Implements front-end functionality on newspaper page table to display groups, as well as ability to add and remove groups when creating and editing newspapers.

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- NewspaperGroups table added to Prisma schema and database

### How to Test

1. Create a new newspaper and a new group in the add newspaper modal.
2. Verify group is correctly displayed in newspaper table.
3. Edit the newspaper and remove/add other groups.
4. Verify groups are correctly updated in the newspaper table.
5. Create multiple newspapers and associate them with a specific group.