### PR TITLE
Add mail API route

### DIFF
--- a/pages/api/mail.js
+++ b/pages/api/mail.js
@@ -1,0 +1,37 @@
+import nodemailer from "nodemailer";
+
+
+async function handler(req, res) {
+    if (req.method === "POST") {
+        await emailVolunteers(req, res);
+    }
+};
+
+async function emailVolunteers(req, res) {
+    const { emails } = req.body;
+    const testAccount = await nodemailer.createTestAccount();
+    // Update to use Mailchimp SMTP server and API key
+    const transporter = nodemailer.createTransport({
+        host: "smtp.ethereal.email",
+        port: 587,
+        secure: false,
+        auth: {
+            user: testAccount.user,
+            pass: testAccount.pass
+        }
+    });
+
+    const mailOptions = {
+        from: '"Manu Gupta" <manu@bitsofgood.org>', // replace with Manu's address
+        to: emails.toString(),
+        subject: "Test email",
+        text: "Hello world!",
+        html: "<b>Hello world!</b>"
+    };
+
+    const mailInfo = await transporter.sendMail(mailOptions);
+    console.log("Message sent: %s", mailInfo.messageId);
+    res.status(200).json({});
+};
+
+export default handler;


### PR DESCRIPTION
## Adds Mail API route

Issue Number(s): #51 . 

Adds API route to email a list a volunteers. This PR will be updated to use the Mailchimp SMTP server once we have the proper credentials.

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- Database change / migration to run
- Environment config change
- Breaking API change

### Related PRs

### How to Test

1. Send an API request to the `/api/mail` route with a list of emails in the body
2. Verify that the server logs a valid etheral message id